### PR TITLE
fix compilation with latest V and vfmt tvintris.v

### DIFF
--- a/examples/tvintris/tvintris.v
+++ b/examples/tvintris/tvintris.v
@@ -343,7 +343,7 @@ fn main() {
 	game2.k_up = p2up
 	game2.k_down = p2down
 	game2.k_left = p2left
-	game2.k_right = p2left
+	game2.k_right = p2right
 	//
 	game2.jb_fire = jbp2fire
 	game2.jh_up = jhp2up

--- a/examples/tvintris/tvintris.v
+++ b/examples/tvintris/tvintris.v
@@ -7,71 +7,74 @@
 
 module main
 
-import rand
 import time
 import os
 import math
 import nsauzede.vsdl2
 import nsauzede.vsdl2.image as img
-[inline] fn sdl_fill_rect(s &vsdl2.Surface,r &vsdl2.Rect,c &vsdl2.Color){vsdl2.fill_rect(s,r,c)}
+
+[inline]
+fn sdl_fill_rect(s &vsdl2.Surface, r &vsdl2.Rect, c &vsdl2.Color) {
+	vsdl2.fill_rect(s, r, c)
+}
 
 const (
-	vsdl2_version = vsdl2.version
-	Title = 'tVintris'
-	BASE = os.dir( os.real_path( os.executable() ) )
-	font_name = BASE + '/fonts/RobotoMono-Regular.ttf'
-	music_name = BASE + '/sounds/TwintrisThosenine.mod'
-	snd_block_name = BASE + '/sounds/block.wav'
-	snd_line_name = BASE + '/sounds/single.wav'
-	snd_double_name = BASE + '/sounds/triple.wav'
-	VLogo = BASE + '/images/v-logo_30_30.png'
-	BlockSize = 20 // pixels
-	FieldHeight = 20 // # of blocks
-	FieldWidth = 10
-	TetroSize = 4
-	WinWidth = BlockSize * FieldWidth * 3
-	WinHeight = BlockSize * FieldHeight
-	TimerPeriod = 250 // ms
-	TextSize = 16
-	AudioBufSize = 1024
+	vsdl2_version     = vsdl2.version
+	title             = 'tVintris'
+	base              = os.resource_abs_path('.')
+	font_name         = base + '/fonts/RobotoMono-Regular.ttf'
+	music_name        = base + '/sounds/TwintrisThosenine.mod'
+	snd_block_name    = base + '/sounds/block.wav'
+	snd_line_name     = base + '/sounds/single.wav'
+	snd_double_name   = base + '/sounds/triple.wav'
+	vlogo             = base + '/images/v-logo_30_30.png'
+	block_size        = 20 // pixels
+	field_height      = 20 // # of blocks
+	field_width       = 10
+	tetro_size        = 4
+	win_width         = block_size * field_width * 3
+	win_height        = block_size * field_height
+	timer_period      = 250 // ms
+	text_size         = 16
+	audio_buffer_size = 1024
 
-	P2FIRE = C.SDLK_l
-	P2UP = C.SDLK_UP
-	P2DOWN = C.SDLK_DOWN
-	P2LEFT = C.SDLK_LEFT
-	P2RIGHT = C.SDLK_RIGHT
+	p2fire            = C.SDLK_l
+	p2up              = C.SDLK_UP
+	p2down            = C.SDLK_DOWN
+	p2left            = C.SDLK_LEFT
+	p2right           = C.SDLK_RIGHT
 
-	P1FIRE = C.SDLK_s
-	P1UP = C.SDLK_w
-	P1DOWN = C.SDLK_x
-	P1LEFT = C.SDLK_a
-	P1RIGHT = C.SDLK_d
+	p1fire            = C.SDLK_s
+	p1up              = C.SDLK_w
+	p1down            = C.SDLK_x
+	p1left            = C.SDLK_a
+	p1right           = C.SDLK_d
 
-	NJOYMAX = 2
+	njoymax           = 2
 	// joystick name => enter your own device name
-	JOYP1NAME = 'Generic X-Box pad'
+	joyp1name         = 'Generic X-Box pad'
 	// following are joystick button number
-	JBP1FIRE = 1
+	jbp1fire          = 1
 	// following are joystick hat value
-	JHP1UP = 1
-	JHP1DOWN = 4
-	JHP1LEFT = 8
-	JHP1RIGHT = 3
+	jhp1up            = 1
+	jhp1down          = 4
+	jhp1left          = 8
+	jhp1right         = 3
 
 	// joystick name => enter your own device name
-	JOYP2NAME = 'RedOctane Guitar Hero X-plorer'
+	joyp2name         = 'RedOctane Guitar Hero X-plorer'
 	// following are joystick button number
-	JBP2FIRE = 0
+	jbp2fire          = 0
 	// following are joystick hat value
-	JHP2UP = 4
-	JHP2DOWN = 1
-	JHP2LEFT = 8
-	JHP2RIGHT = 2
+	jhp2up            = 4
+	jhp2down          = 1
+	jhp2left          = 8
+	jhp2right         = 2
 )
 
 const (
 	// Tetros' 4 possible states are encoded in binaries
-	b_tetros = [
+	b_tetros         = [
 		// 0000 0
 		// 0000 0
 		// 0110 6
@@ -107,111 +110,113 @@ const (
 		[1111, 9, 1111, 9],
 	]
 	// Each tetro has its unique color
-	Colors = [
-		vsdl2.Color{byte(0), byte(0), byte(0), byte(0)},		// unused ?
-		vsdl2.Color{byte(0), byte(0x62), byte(0xc0), byte(0)},	// quad : darkblue 0062c0
-		vsdl2.Color{byte(0xca), byte(0x7d), byte(0x5f), byte(0)},	// tricorn : lightbrown ca7d5f
-		vsdl2.Color{byte(0), byte(0xc1), byte(0xbf), byte(0)},	// short topright : lightblue 00c1bf
-		vsdl2.Color{byte(0), byte(0xc1), byte(0), byte(0)},	// short topleft : lightgreen 00c100
-		vsdl2.Color{byte(0xbf), byte(0xbe), byte(0), byte(0)},	// long topleft : yellowish bfbe00
-		vsdl2.Color{byte(0xd1), byte(0), byte(0xbf), byte(0)},	// long topright : pink d100bf
-		vsdl2.Color{byte(0xd1), byte(0), byte(0), byte(0)},	// longest : lightred d10000
-		vsdl2.Color{byte(0), byte(170), byte(170), byte(0)},	// unused ?
+	colors           = [
+		vsdl2.Color{byte(0), byte(0), byte(0), byte(0)}, // unused ?
+		vsdl2.Color{byte(0), byte(0x62), byte(0xc0), byte(0)}, // quad : darkblue 0062c0
+		vsdl2.Color{byte(0xca), byte(0x7d), byte(0x5f), byte(0)}, // tricorn : lightbrown ca7d5f
+		vsdl2.Color{byte(0), byte(0xc1), byte(0xbf), byte(0)}, // short topright : lightblue 00c1bf
+		vsdl2.Color{byte(0), byte(0xc1), byte(0), byte(0)}, // short topleft : lightgreen 00c100
+		vsdl2.Color{byte(0xbf), byte(0xbe), byte(0), byte(0)}, // long topleft : yellowish bfbe00
+		vsdl2.Color{byte(0xd1), byte(0), byte(0xbf), byte(0)}, // long topright : pink d100bf
+		vsdl2.Color{byte(0xd1), byte(0), byte(0), byte(0)}, // longest : lightred d10000
+		vsdl2.Color{byte(0), byte(170), byte(170), byte(0)}, // unused ?
 	]
 	// Background color
-	BackgroundColor = vsdl2.Color{byte(0), byte(0), byte(0), byte(0)}
-//	BackgroundColor = vsdl2.Color{byte(255), byte(255), byte(255), byte(0)}
+	background_color = vsdl2.Color{byte(0), byte(0), byte(0), byte(0)}
+	//	background_color = vsdl2.Color{byte(255), byte(255), byte(255), byte(0)}
 	// Foreground color
-	ForegroundColor = vsdl2.Color{byte(0), byte(170), byte(170), byte(0)}
-//	ForegroundColor = vsdl2.Color{byte(0), byte(0), byte(0), byte(0)}
+	foreground_color = vsdl2.Color{byte(0), byte(170), byte(170), byte(0)}
+	//	foreground_color = vsdl2.Color{byte(0), byte(0), byte(0), byte(0)}
 	// Text color
-	TextColor = vsdl2.Color{byte(0xca), byte(0x7d), byte(0x5f), byte(0)}
-//	TextColor = vsdl2.Color{byte(0), byte(0), byte(0), byte(0)}
+	text_color       = vsdl2.Color{byte(0xca), byte(0x7d), byte(0x5f), byte(0)}
+		//	text_color = vsdl2.Color{byte(0), byte(0), byte(0), byte(0)}
 )
 
-// TODO: type Tetro [TetroSize]struct{ x, y int }
+// TODO: type Tetro [tetro_size]struct{ x, y int }
 struct Block {
-	mut:
+mut:
 	x int
 	y int
 }
 
 enum GameState {
-        paused running gameover
+	paused
+	running
+	gameover
 }
 
 struct AudioContext {
 mut:
-	music voidptr
+	music  voidptr
 	volume int
-        waves [3]voidptr
+	waves  [3]voidptr
 }
 
 struct SdlContext {
 pub mut:
-//	VIDEO
-	w		int
-	h		int
-	window          voidptr
-	renderer        voidptr
-	screen          &vsdl2.Surface
-	texture         voidptr
-//	AUDIO
-	actx		AudioContext
-//	JOYSTICKS
-	jnames		[2]string
-	jids		[2]int
-//	V logo
-	v_logo		&vsdl2.Surface
-	tv_logo		voidptr
+	//	VIDEO
+	w        int
+	h        int
+	window   voidptr
+	renderer voidptr
+	screen   &vsdl2.Surface
+	texture  voidptr
+	//	AUDIO
+	actx AudioContext
+	//	JOYSTICKS
+	jnames [2]string
+	jids   [2]int
+	//	V logo
+	v_logo  &vsdl2.Surface
+	tv_logo voidptr
 }
 
 struct Game {
 mut:
 	// Score of the current game
-	score        int
+	score int
 	// Count consecutive lines for scoring
-	lines        int
+	lines int
 	// State of the current game
-	state    GameState
+	state GameState
 	// X offset of the game display
-	ofs_x           int
+	ofs_x int
 	// keys
-	k_fire          int
-	k_up            int
-	k_down          int
-	k_left          int
-	k_right         int
+	k_fire  int
+	k_up    int
+	k_down  int
+	k_left  int
+	k_right int
 	// joystick ID
-	joy_id           int
+	joy_id int
 	// joystick buttons
-	jb_fire          int
+	jb_fire int
 	// joystick hat values
-	jh_up            int
-	jh_down          int
-	jh_left          int
-	jh_right         int
+	jh_up    int
+	jh_down  int
+	jh_left  int
+	jh_right int
 	// game rand seed
-	seed            int
-	seed_ini            int
+	seed     int
+	seed_ini int
 	// Position of the current tetro
-	pos_x        int
-	pos_y        int
+	pos_x int
+	pos_y int
 	// field[y][x] contains the color of the block with (x,y) coordinates
 	// "-1" border is to avoid bounds checking.
 	// -1 -1 -1 -1
 	// -1  0  0 -1
 	// -1  0  0 -1
 	// -1 -1 -1 -1
-	field       [][]int
+	field [][]int
 	// TODO: tetro Tetro
-	tetro       []Block
+	tetro []Block
 	// TODO: tetros_cache []Tetro
 	tetros_cache []Block
 	// Index of the current tetro. Refers to its color.
-	tetro_idx    int
+	tetro_idx int
 	// Index of the next tetro. Refers to its color.
-	tetro_next    int
+	tetro_next int
 	// tetro stats : buckets of drawn tetros
 	tetro_stats []int
 	// total number of drawn tetros
@@ -219,21 +224,13 @@ mut:
 	// Index of the rotation (0-3)
 	rotation_idx int
 	// SDL2 context for drawing
-	sdl             SdlContext
+	sdl SdlContext
 	// TTF context for font drawing
-	font            voidptr
+	font voidptr
 }
-/*
-fn C.rand() int
-pub fn seed(s int) {
-	C.srand(s)
-}
-pub fn next(max int) int {
-	return C.rand() % max
-}
-*/
+
 fn rand_r(seed &int) int {
-	unsafe{
+	unsafe {
 		mut rs := seed
 		ns := (*rs * 1103515245 + 12345)
 		*rs = ns
@@ -241,25 +238,26 @@ fn rand_r(seed &int) int {
 	}
 }
 
-
-fn (sdl mut SdlContext) set_sdl_context(w int, h int, title string) {
+fn (mut sdl SdlContext) set_sdl_context(w int, h int, title string) {
 	C.SDL_Init(C.SDL_INIT_VIDEO | C.SDL_INIT_AUDIO | C.SDL_INIT_JOYSTICK)
 	C.atexit(C.SDL_Quit)
 	C.TTF_Init()
 	C.atexit(C.TTF_Quit)
 	bpp := 32
 	vsdl2.create_window_and_renderer(w, h, 0, &sdl.window, &sdl.renderer)
-//	C.SDL_CreateWindowAndRenderer(w, h, 0, voidptr(&sdl.window), voidptr(&sdl.renderer))
+	//	C.SDL_CreateWindowAndRenderer(w, h, 0, voidptr(&sdl.window), voidptr(&sdl.renderer))
 	C.SDL_SetWindowTitle(sdl.window, title.str)
 	sdl.w = w
 	sdl.h = h
-	sdl.screen = vsdl2.create_rgb_surface(0, w, h, bpp, 0x00FF0000, 0x0000FF00, 0x000000FF, 0xFF000000)
-	sdl.texture = C.SDL_CreateTexture(sdl.renderer, C.SDL_PIXELFORMAT_ARGB8888, C.SDL_TEXTUREACCESS_STREAMING, w, h)
+	sdl.screen = vsdl2.create_rgb_surface(0, w, h, bpp, 0x00FF0000, 0x0000FF00, 0x000000FF,
+		0xFF000000)
+	sdl.texture = C.SDL_CreateTexture(sdl.renderer, C.SDL_PIXELFORMAT_ARGB8888, C.SDL_TEXTUREACCESS_STREAMING,
+		w, h)
 
 	C.Mix_Init(0)
 	C.atexit(voidptr(C.Mix_Quit))
-	if C.Mix_OpenAudio(48000,C.MIX_DEFAULT_FORMAT,2,AudioBufSize) < 0 {
-		println('couldn\'t open audio')
+	if C.Mix_OpenAudio(48000, C.MIX_DEFAULT_FORMAT, 2, audio_buffer_size) < 0 {
+		println("couldn't open audio")
 	}
 	println('opening music $music_name')
 	sdl.actx.music = C.Mix_LoadMUS(music_name.str)
@@ -273,9 +271,9 @@ fn (sdl mut SdlContext) set_sdl_context(w int, h int, title string) {
 	njoy := C.SDL_NumJoysticks()
 	for i := 0; i < njoy; i++ {
 		C.SDL_JoystickOpen(i)
-		jn := tos_clone(vsdl2.joystick_name_for_index(i))
+		jn := unsafe { tos_clone(vsdl2.joystick_name_for_index(i)) }
 		println('JOY NAME $jn')
-		for j := 0; j < NJOYMAX; j++ {
+		for j := 0; j < njoymax; j++ {
 			if sdl.jnames[j] == jn {
 				println('FOUND JOYSTICK $j $jn ID=$i')
 				sdl.jids[j] = i
@@ -287,73 +285,82 @@ fn (sdl mut SdlContext) set_sdl_context(w int, h int, title string) {
 	if (imgres & flags) != flags {
 		println('error initializing image library.')
 	}
-	println('opening logo $VLogo')
-	sdl.v_logo = img.load(VLogo)
+	println('opening logo $vlogo')
+	sdl.v_logo = img.load(vlogo)
 	if !isnil(sdl.v_logo) {
-//		println('got v_logo=$sdl.v_logo')
+		//		println('got v_logo=$sdl.v_logo')
 		sdl.tv_logo = vsdl2.create_texture_from_surface(sdl.renderer, sdl.v_logo)
-//		println('got tv_logo=$sdl.tv_logo')
+		//		println('got tv_logo=$sdl.tv_logo')
 	}
 	C.SDL_JoystickEventState(C.SDL_ENABLE)
 }
 
 fn main() {
 	println('tVintris -- tribute to venerable Twintris')
-	mut game := &Game{ font: 0 }
-	game.sdl.jnames[0] = JOYP1NAME
-	game.sdl.jnames[1] = JOYP2NAME
+	mut game := &Game{
+		font: 0
+	}
+	game.sdl.jnames[0] = joyp1name
+	game.sdl.jnames[1] = joyp2name
 	game.sdl.jids[0] = -1
 	game.sdl.jids[1] = -1
-	game.sdl.set_sdl_context(WinWidth, WinHeight, Title)
-	game.font = C.TTF_OpenFont(font_name.str, TextSize)
+	game.sdl.set_sdl_context(win_width, win_height, title)
+	game.font = C.TTF_OpenFont(font_name.str, text_size)
 	seed := time.now().unix
-	mut game2 := &Game{ font: 0 }
+	mut game2 := &Game{
+		font: 0
+	}
 	game2.sdl = game.sdl
 	game2.font = game.font
 
 	game.joy_id = game.sdl.jids[0]
-//	println('JOY1 id=${game.joy_id}')
+	//	println('JOY1 id=${game.joy_id}')
 	game2.joy_id = game.sdl.jids[1]
-//	println('JOY2 id=${game2.joy_id}')
+	//	println('JOY2 id=${game2.joy_id}')
 
 	// delay uses milliseconds so 1000 ms / 30 frames (30fps) roughly = 33.3333 ms/frame
-	time_per_frame := 1000.0 / 30.0 
+	time_per_frame := 1000.0 / 30.0
 
-	game.k_fire = P1FIRE
-	game.k_up = P1UP
-	game.k_down = P1DOWN
-	game.k_left = P1LEFT
-	game.k_right = P1RIGHT
-	game.jb_fire = JBP1FIRE
-	game.jh_up = JHP1UP
-	game.jh_down = JHP1DOWN
-	game.jh_left = JHP1LEFT
-	game.jh_right = JHP1RIGHT
+	game.k_fire = p1fire
+	game.k_up = p1up
+	game.k_down = p1down
+	game.k_left = p1left
+	game.k_right = p1right
+	//
+	game.jb_fire = jbp1fire
+	game.jh_up = jhp1up
+	game.jh_down = jhp1down
+	game.jh_left = jhp1left
+	game.jh_right = jhp1right
+	//
 	game.ofs_x = 0
 	game.seed_ini = int(seed)
 	game.init_game()
 	game.state = .running
 	go game.run() // Run the game loop in a new thread
 
-	game2.k_fire = P2FIRE
-	game2.k_up = P2UP
-	game2.k_down = P2DOWN
-	game2.k_left = P2LEFT
-	game2.k_right = P2RIGHT
-	game2.jb_fire = JBP2FIRE
-	game2.jh_up = JHP2UP
-	game2.jh_down = JHP2DOWN
-	game2.jh_left = JHP2LEFT
-	game2.jh_right = JHP2RIGHT
-	game2.ofs_x = WinWidth * 2 / 3
+	game2.k_fire = p2fire
+	game2.k_up = p2up
+	game2.k_down = p2down
+	game2.k_left = p2left
+	game2.k_right = p2left
+	//
+	game2.jb_fire = jbp2fire
+	game2.jh_up = jhp2up
+	game2.jh_down = jhp2down
+	game2.jh_left = jhp2left
+	game2.jh_right = jhp2right
+	//
+	game2.ofs_x = win_width * 2 / 3
 	game2.seed_ini = int(seed)
 	game2.init_game()
 	game2.state = .running
 	go game2.run() // Run the game loop in a new thread
 
-	mut g := Game{ font: 0 }
+	mut g := Game{
+		font: 0
+	}
 	mut should_close := false
-	mut total_frame_ticks := u64(0)
 	mut total_frames := u32(0)
 
 	for {
@@ -387,32 +394,34 @@ fn main() {
 		g.draw_v_logo()
 		g.draw_end()
 
-//		game.handle_events()            // CRASHES if done in function ???
+		//		game.handle_events()            // CRASHES if done in function ???
 		ev := vsdl2.Event{}
 		for 0 < vsdl2.poll_event(&ev) {
-			match int(ev.@type) {
-				C.SDL_QUIT { should_close = true }
+			match int(unsafe { ev.@type }) {
+				C.SDL_QUIT {
+					should_close = true
+				}
 				C.SDL_KEYDOWN {
-					key := ev.key.keysym.sym
+					key := unsafe { ev.key.keysym.sym }
 					if key == C.SDLK_ESCAPE {
-					        should_close = true
-					        break
+						should_close = true
+						break
 					}
 					game.handle_key(key)
 					game2.handle_key(key)
 				}
 				C.SDL_JOYBUTTONDOWN {
-					jb := int(ev.jbutton.button)
-					joyid := ev.jbutton.which
-//					println('JOY BUTTON $jb $joyid')
+					jb := int(unsafe { ev.jbutton.button })
+					joyid := unsafe { ev.jbutton.which }
+					//					println('JOY BUTTON $jb $joyid')
 					game.handle_jbutton(jb, joyid)
 					game2.handle_jbutton(jb, joyid)
 				}
 				C.SDL_JOYHATMOTION {
-					jh := int(ev.jhat.hat)
-					jv := int(ev.jhat.value)
-					joyid := ev.jhat.which
-//					println('JOY HAT $jh $jv $joyid')
+					jh := int(unsafe { ev.jhat.hat })
+					jv := int(unsafe { ev.jhat.value })
+					joyid := unsafe { ev.jhat.which }
+					//					println('JOY HAT $jh $jv $joyid')
 					game.handle_jhat(jh, jv, joyid)
 					game2.handle_jhat(jh, jv, joyid)
 				}
@@ -423,13 +432,12 @@ fn main() {
 			break
 		}
 		end_ticks := vsdl2.get_perf_counter()
-		
-		total_frame_ticks += end_ticks-start_ticks
+
 		elapsed_time := f64(end_ticks - start_ticks) / f64(vsdl2.get_perf_frequency())
 		// current_fps := 1.0 / elapsed_time
-		
+
 		// should limit system to (1 / time_per_frame) fps
-		vsdl2.delay(u32(math.floor(time_per_frame - elapsed_time)))  
+		vsdl2.delay(u32(math.floor(time_per_frame - elapsed_time)))
 	}
 	if game.font != voidptr(0) {
 		C.TTF_CloseFont(game.font)
@@ -456,9 +464,12 @@ fn main() {
 }
 
 enum Action {
-        idle space fire
+	idle
+	space
+	fire
 }
-fn (game mut Game) handle_key(key int) {
+
+fn (mut game Game) handle_key(key int) {
 	// global keys
 	mut action := Action.idle
 	match key {
@@ -468,29 +479,31 @@ fn (game mut Game) handle_key(key int) {
 	}
 
 	if action == .space {
-			match game.state {
-				.running {
-					C.Mix_PauseMusic()
-					game.state = .paused
-				}
-				.paused {
-					C.Mix_ResumeMusic()
-					game.state = .running
-				}
-				else {}
+		match game.state {
+			.running {
+				C.Mix_PauseMusic()
+				game.state = .paused
 			}
+			.paused {
+				C.Mix_ResumeMusic()
+				game.state = .running
+			}
+			else {}
+		}
 	}
 
 	if action == .fire {
-			match game.state {
-				.gameover {
-					game.init_game()
-					game.state = .running
-				}
-				else {}
+		match game.state {
+			.gameover {
+				game.init_game()
+				game.state = .running
 			}
+			else {}
+		}
 	}
-	if game.state != .running { return }
+	if game.state != .running {
+		return
+	}
 	// keys while game is running
 	match key {
 		game.k_up { game.rotate_tetro() }
@@ -501,7 +514,7 @@ fn (game mut Game) handle_key(key int) {
 	}
 }
 
-fn (game mut Game) handle_jbutton(jb int, joyid int) {
+fn (mut game Game) handle_jbutton(jb int, joyid int) {
 	if joyid != game.joy_id {
 		return
 	}
@@ -513,22 +526,24 @@ fn (game mut Game) handle_jbutton(jb int, joyid int) {
 	}
 
 	if action == .fire {
-			match game.state {
-				.gameover {
-					game.init_game()
-					game.state = .running
-				}
-				else {}
+		match game.state {
+			.gameover {
+				game.init_game()
+				game.state = .running
 			}
+			else {}
+		}
 	}
 }
 
-fn (game mut Game) handle_jhat(jh int, jv int, joyid int) {
+fn (mut game Game) handle_jhat(jh int, jv int, joyid int) {
 	if joyid != game.joy_id {
 		return
 	}
-	if game.state != .running { return }
-//	println('testing hat values.. joyid=$joyid jh=$jh jv=$jv')
+	if game.state != .running {
+		return
+	}
+	//	println('testing hat values.. joyid=$joyid jh=$jh jv=$jv')
 	// hat values while game is running
 	match jv {
 		game.jh_up { game.rotate_tetro() }
@@ -539,7 +554,7 @@ fn (game mut Game) handle_jhat(jh int, jv int, joyid int) {
 	}
 }
 
-fn (g mut Game) init_game() {
+fn (mut g Game) init_game() {
 	g.score = 0
 	g.tetro_total = 0
 	g.tetro_stats = [0, 0, 0, 0, 0, 0, 0]
@@ -548,21 +563,21 @@ fn (g mut Game) init_game() {
 	g.generate_tetro()
 	g.field = []
 	// Generate the field, fill it with 0's, add -1's on each edge
-	for i := 0; i < FieldHeight + 2; i++ {
-		mut row := [0].repeat(FieldWidth + 2)
-		row[0] = - 1
-		row[FieldWidth + 1] = - 1
+	for i := 0; i < field_height + 2; i++ {
+		mut row := [0].repeat(field_width + 2)
+		row[0] = -1
+		row[field_width + 1] = -1
 		g.field << row
 	}
 	mut first_row := g.field[0]
-	mut last_row := g.field[FieldHeight + 1]
-	for j := 0; j < FieldWidth + 2; j++ {
-		first_row[j] = - 1
-		last_row[j] = - 1
+	mut last_row := g.field[field_height + 1]
+	for j := 0; j < field_width + 2; j++ {
+		first_row[j] = -1
+		last_row[j] = -1
 	}
 }
 
-fn (g mut Game) parse_tetros() {
+fn (mut g Game) parse_tetros() {
 	for btetros in b_tetros {
 		for btetro in btetros {
 			for t in parse_binary_tetro(btetro) {
@@ -572,7 +587,7 @@ fn (g mut Game) parse_tetros() {
 	}
 }
 
-fn (g mut Game) run() {
+fn (mut g Game) run() {
 	for {
 		if g.state == .running {
 			g.move_tetro()
@@ -591,15 +606,15 @@ fn (g mut Game) run() {
 				}
 			}
 		}
-		time.sleep_ms(TimerPeriod)      // medium delay between game step
+		time.sleep(timer_period * time.millisecond) // medium delay between game step
 	}
 }
 
-fn (game mut Game) rotate_tetro() {
+fn (mut game Game) rotate_tetro() {
 	// Rotate the tetro
 	old_rotation_idx := game.rotation_idx
 	game.rotation_idx++
-	if game.rotation_idx == TetroSize {
+	if game.rotation_idx == tetro_size {
 		game.rotation_idx = 0
 	}
 	game.get_tetro()
@@ -612,14 +627,14 @@ fn (game mut Game) rotate_tetro() {
 	}
 }
 
-fn (g mut Game) move_tetro() {
+fn (mut g Game) move_tetro() {
 	// Check each block in current tetro
 	for block in g.tetro {
 		y := block.y + g.pos_y + 1
 		x := block.x + g.pos_x
 		// Reached the bottom of the screen or another block?
 		// TODO: if g.field[y][x] != 0
-		//if g.field[y][x] != 0 {
+		// if g.field[y][x] != 0 {
 		row := g.field[y]
 		if row[x] != 0 {
 			// The new tetro has no space to drop => end of the game
@@ -638,9 +653,9 @@ fn (g mut Game) move_tetro() {
 	g.pos_y++
 }
 
-fn (g mut Game) move_right(dx int) bool {
+fn (mut g Game) move_right(dx int) bool {
 	// Reached left/right edge or another tetro?
-	for i := 0; i < TetroSize; i++ {
+	for i := 0; i < tetro_size; i++ {
 		tetro := g.tetro[i]
 		y := tetro.y + g.pos_y
 		x := tetro.x + g.pos_x + dx
@@ -656,14 +671,14 @@ fn (g mut Game) move_right(dx int) bool {
 
 fn (g &Game) delete_completed_lines() int {
 	mut n := 0
-	for y := FieldHeight; y >= 1; y-- {
+	for y := field_height; y >= 1; y-- {
 		n += g.delete_completed_line(y)
 	}
 	return n
 }
 
 fn (g &Game) delete_completed_line(y int) int {
-	for x := 1; x <= FieldWidth; x++ {
+	for x := 1; x <= field_width; x++ {
 		f := g.field[y]
 		if f[x] == 0 {
 			return 0
@@ -671,7 +686,7 @@ fn (g &Game) delete_completed_line(y int) int {
 	}
 	// Move everything down by 1 position
 	for yy := y - 1; yy >= 1; yy-- {
-		for x := 1; x <= FieldWidth; x++ {
+		for x := 1; x <= field_width; x++ {
 			mut a := g.field[yy + 1]
 			b := g.field[yy]
 			a[x] = b[x]
@@ -681,7 +696,7 @@ fn (g &Game) delete_completed_line(y int) int {
 }
 
 // Draw a rand tetro index
-fn (g mut Game) rand_tetro() int {
+fn (mut g Game) rand_tetro() int {
 	cur := g.tetro_next
 	g.tetro_next = rand_r(&g.seed)
 	g.tetro_next = g.tetro_next % b_tetros.len
@@ -689,25 +704,25 @@ fn (g mut Game) rand_tetro() int {
 }
 
 // Place a new tetro on top
-fn (g mut Game) generate_tetro() {
+fn (mut g Game) generate_tetro() {
 	g.pos_y = 0
-	g.pos_x = FieldWidth / 2 - TetroSize / 2
+	g.pos_x = field_width / 2 - tetro_size / 2
 	g.tetro_idx = g.rand_tetro()
-//	println('idx=${g.tetro_idx}')
-	g.tetro_stats[g.tetro_idx] += 2 -1
+	//	println('idx=${g.tetro_idx}')
+	g.tetro_stats[g.tetro_idx] += 2 - 1
 	g.tetro_total++
 	g.rotation_idx = 0
 	g.get_tetro()
 }
 
 // Get the right tetro from cache
-fn (g mut Game) get_tetro() {
-	idx := g.tetro_idx * TetroSize * TetroSize + g.rotation_idx * TetroSize
-	g.tetro = g.tetros_cache[idx .. idx + TetroSize]
+fn (mut g Game) get_tetro() {
+	idx := g.tetro_idx * tetro_size * tetro_size + g.rotation_idx * tetro_size
+	g.tetro = g.tetros_cache[idx..idx + tetro_size]
 }
 
 fn (g &Game) drop_tetro() {
-	for i := 0; i < TetroSize; i++ {
+	for i := 0; i < tetro_size; i++ {
 		tetro := g.tetro[i]
 		x := tetro.x + g.pos_x
 		y := tetro.y + g.pos_y
@@ -719,22 +734,21 @@ fn (g &Game) drop_tetro() {
 }
 
 fn (g &Game) draw_tetro() {
-	for i := 0; i < TetroSize; i++ {
+	for i := 0; i < tetro_size; i++ {
 		tetro := g.tetro[i]
 		g.draw_block(g.pos_y + tetro.y, g.pos_x + tetro.x, g.tetro_idx + 1)
 	}
 }
 
-fn (g &Game) draw_block(i, j, color_idx int) {
-	rect := vsdl2.Rect {g.ofs_x + (j - 1) * BlockSize, (i - 1) * BlockSize,
-		BlockSize - 1, BlockSize - 1}
-	col := Colors[color_idx]
+fn (g &Game) draw_block(i int, j int, color_idx int) {
+	rect := vsdl2.Rect{g.ofs_x + (j - 1) * block_size, (i - 1) * block_size, block_size - 1, block_size - 1}
+	col := colors[color_idx]
 	sdl_fill_rect(g.sdl.screen, &rect, &col)
 }
 
 fn (g &Game) draw_field() {
-	for i := 1; i < FieldHeight + 1; i++ {
-		for j := 1; j < FieldWidth + 1; j++ {
+	for i := 1; i < field_height + 1; i++ {
+		for j := 1; j < field_width + 1; j++ {
 			f := g.field[i]
 			if f[j] > 0 {
 				g.draw_block(i, j, f[j])
@@ -750,9 +764,9 @@ fn (g &Game) draw_v_logo() {
 	texw := 0
 	texh := 0
 	C.SDL_QueryTexture(g.sdl.tv_logo, 0, 0, &texw, &texh)
-	dstrect := vsdl2.Rect { (WinWidth / 2) - (texw / 2), 20, texw, texh }
+	dstrect := vsdl2.Rect{(win_width / 2) - (texw / 2), 20, texw, texh}
 	// Currently we can't seem to use vsdl2.render_copy when we need to pass a nil pointer (eg: srcrect to be NULL)
-//	vsdl2.render_copy(g.sdl.renderer, tv_logo, 0, &dstrect)
+	//	vsdl2.render_copy(g.sdl.renderer, tv_logo, 0, &dstrect)
 	C.SDL_RenderCopy(g.sdl.renderer, g.sdl.tv_logo, voidptr(0), voidptr(&dstrect))
 }
 
@@ -763,30 +777,31 @@ fn (g &Game) draw_text(x int, y int, text string, tcol vsdl2.Color) {
 	texw := 0
 	texh := 0
 	C.SDL_QueryTexture(ttext, 0, 0, &texw, &texh)
-	dstrect := vsdl2.Rect { x, y, texw, texh }
-//	vsdl2.render_copy(g.sdl.renderer, ttext, 0, &dstrect)
+	dstrect := vsdl2.Rect{x, y, texw, texh}
+	//	vsdl2.render_copy(g.sdl.renderer, ttext, 0, &dstrect)
 	C.SDL_RenderCopy(g.sdl.renderer, ttext, voidptr(0), voidptr(&dstrect))
 	C.SDL_DestroyTexture(ttext)
 	vsdl2.free_surface(tsurf)
 }
 
-[inline] fn (g &Game) draw_ptext(x int, y int, text string, tcol vsdl2.Color) {
+[inline]
+fn (g &Game) draw_ptext(x int, y int, text string, tcol vsdl2.Color) {
 	g.draw_text(g.ofs_x + x, y, text, tcol)
 }
 
 [live]
 fn (g &Game) draw_begin() {
-//	println('about to clear')
+	//	println('about to clear')
 	C.SDL_RenderClear(g.sdl.renderer)
-	mut rect := vsdl2.Rect {0,0,g.sdl.w,g.sdl.h}
-	col := vsdl2.Color{byte(00), byte(00), byte(0), byte(0)}
-//	sdl_fill_rect(g.sdl.screen, &rect, BackgroundColor)
+	mut rect := vsdl2.Rect{0, 0, g.sdl.w, g.sdl.h}
+	col := vsdl2.Color{byte(0), byte(0), byte(0), byte(0)}
+	//	sdl_fill_rect(g.sdl.screen, &rect, background_color)
 	sdl_fill_rect(g.sdl.screen, &rect, col)
 
-	rect = vsdl2.Rect {BlockSize * FieldWidth + 2,0,2,g.sdl.h}
-	sdl_fill_rect(g.sdl.screen, &rect, ForegroundColor)
-	rect = vsdl2.Rect {WinWidth - BlockSize * FieldWidth - 4,0,2,g.sdl.h}
-	sdl_fill_rect(g.sdl.screen, &rect, ForegroundColor)
+	rect = vsdl2.Rect{block_size * field_width + 2, 0, 2, g.sdl.h}
+	sdl_fill_rect(g.sdl.screen, &rect, foreground_color)
+	rect = vsdl2.Rect{win_width - block_size * field_width - 4, 0, 2, g.sdl.h}
+	sdl_fill_rect(g.sdl.screen, &rect, foreground_color)
 
 	mut idx := 0
 	for st in g.tetro_stats {
@@ -794,36 +809,37 @@ fn (g &Game) draw_begin() {
 		if g.tetro_total > 0 {
 			s += 90 * st / g.tetro_total
 		}
-		w := BlockSize
+		w := block_size
 		h := s * 4 * w / 100
-		rect = vsdl2.Rect {(WinWidth - 7 * (w + 1)) / 2 + idx * (w + 1), WinHeight * 3 / 4 - h, w, h}
-		sdl_fill_rect(g.sdl.screen, &rect, Colors[idx + 1])
+		rect = vsdl2.Rect{(win_width - 7 * (w + 1)) / 2 + idx * (w + 1), win_height * 3 / 4 - h, w, h}
+		sdl_fill_rect(g.sdl.screen, &rect, colors[idx + 1])
 		idx++
 	}
 }
 
 fn (g &Game) draw_middle() {
 	C.SDL_UpdateTexture(g.sdl.texture, 0, g.sdl.screen.pixels, g.sdl.screen.pitch)
-//	vsdl2.render_copy(g.sdl.renderer, g.sdl.texture, voidptr(0), voidptr(0))
+	//	vsdl2.render_copy(g.sdl.renderer, g.sdl.texture, voidptr(0), voidptr(0))
 	C.SDL_RenderCopy(g.sdl.renderer, g.sdl.texture, voidptr(0), voidptr(0))
 }
 
 fn (g &Game) draw_score() {
 	if g.font != voidptr(0) {
-		g.draw_ptext(1, 2, 'score: ' + g.score.str() + ' nxt=' + g.tetro_next.str(), TextColor)
+		g.draw_ptext(1, 2, 'score: ' + g.score.str() + ' nxt=' + g.tetro_next.str(), text_color)
 		if g.state == .gameover {
-			g.draw_ptext(1, WinHeight / 2 + 0 * TextSize, 'Game Over', TextColor)
-			g.draw_ptext(1, WinHeight / 2 + 2 * TextSize, 'FIRE to restart', TextColor)
+			g.draw_ptext(1, win_height / 2 + 0 * text_size, 'Game Over', text_color)
+			g.draw_ptext(1, win_height / 2 + 2 * text_size, 'FIRE to restart', text_color)
 		} else if g.state == .paused {
-			g.draw_ptext(1, WinHeight / 2 + 0 * TextSize, 'Game Paused', TextColor)
-			g.draw_ptext(1, WinHeight / 2 + 2 * TextSize, 'SPACE to resume', TextColor)
+			g.draw_ptext(1, win_height / 2 + 0 * text_size, 'Game Paused', text_color)
+			g.draw_ptext(1, win_height / 2 + 2 * text_size, 'SPACE to resume', text_color)
 		}
 	}
 }
 
 fn (g &Game) draw_stats() {
 	if g.font != voidptr(0) {
-		g.draw_text(WinWidth / 3 + 10, WinHeight * 3 / 4 + 0 * TextSize, 'stats: ' + g.tetro_total.str() + ' tetros', TextColor)
+		g.draw_text(win_width / 3 + 10, win_height * 3 / 4 + 0 * text_size, 'stats: ' +
+			g.tetro_total.str() + ' tetros', text_color)
 		mut stats := ''
 		for st in g.tetro_stats {
 			mut s := 0
@@ -833,7 +849,7 @@ fn (g &Game) draw_stats() {
 			stats += ' '
 			stats += s.str()
 		}
-		g.draw_text(WinWidth / 3 - 8, WinHeight * 3 / 4 + 2 * TextSize, stats, TextColor)
+		g.draw_text(win_width / 3 - 8, win_height * 3 / 4 + 2 * text_size, stats, text_color)
 	}
 }
 
@@ -845,7 +861,7 @@ fn parse_binary_tetro(t_ int) []Block {
 	mut t := t_
 	mut res := [Block{}].repeat(4)
 	mut cnt := 0
-	horizontal := t == 9// special case for the horizontal line
+	horizontal := t == 9 // special case for the horizontal line
 	for i := 0; i <= 3; i++ {
 		// Get ith digit of t
 		p := int(math.pow(10, 3 - i))
@@ -855,7 +871,7 @@ fn parse_binary_tetro(t_ int) []Block {
 		for j := 3; j >= 0; j-- {
 			bin := digit % 2
 			digit /= 2
-			if bin == 1 || (horizontal && i == TetroSize - 1) {
+			if bin == 1 || (horizontal && i == tetro_size - 1) {
 				res[cnt].x = j
 				res[cnt].y = i
 				cnt++


### PR DESCRIPTION
This PR contains the following fixes:

* time.sleep_ms(x) => time.sleep(x * time.millisecond)
* consts were snake_cased
* v fmt -w tvintris.v
* unused variables / module imports were removed

The result is that now tvintris.v compiles without warnings/errors
with latest V 0.2.2 1178427 .